### PR TITLE
Correct display model

### DIFF
--- a/Home Assistant with ESPHome/1. Media Control/MediaController-ESPHome-PithyScreen.yaml
+++ b/Home Assistant with ESPHome/1. Media Control/MediaController-ESPHome-PithyScreen.yaml
@@ -107,7 +107,7 @@ image:
 
 display:
   - platform: ssd1306_i2c
-    model: "SH1106 128x64"
+    model: "SSD1306 128x64"
     address: 0x3C
     update_interval: 0.2s
     pages:


### PR DESCRIPTION
Incorrect model causes image to be shifted two pixels to the right